### PR TITLE
Add PR permissions to Sync workflow

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:


### PR DESCRIPTION
Follow up to https://github.com/actions/maven-dependency-submission-action/pull/7 🙇🏻  We switched to a PR workflow but I didn't add in the PR permissions for the token so it failed.

The branch was created and the PR can be made in the UI so this should be the last piece. 